### PR TITLE
=BG= standard jshint module exports

### DIFF
--- a/angularity-reporter.js
+++ b/angularity-reporter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var through = require('through2');
 
 /**
@@ -37,7 +39,7 @@ function angularityJshintReporter() {
       output.push(item);
     }
     if (output.length) {
-      var width = Number(80) || 0;
+      var width = 80;
       var hr    = new Array(width + 1);   // this is a good trick to repeat a character N times
       var start = (width > 0) ? (hr.join('\u25BC') + '\n') : '';
       var stop  = (width > 0) ? (hr.join('\u25B2') + '\n') : '';
@@ -47,4 +49,6 @@ function angularityJshintReporter() {
   });
 }
 
-module.exports = angularityJshintReporter;
+module.exports = {
+  streamReporter: angularityJshintReporter
+};

--- a/index.js
+++ b/index.js
@@ -1,2 +1,3 @@
-// TODO decide whether conform to jshint reporter standard else just bring the implementation into this file
-module.exports = require('./reporter');
+'use strict';
+
+module.exports = require('path').join(__dirname, 'angularity-reporter.js');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angularity-jshint-reporter",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "The default JsHint reporter for projects built using Angularity",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
=BG= change main export to use the convention for jshint reporters
- main file - `index.js` - exports a string containign the absolute path of the actual reporter file
- reporter file exports an object, with the `reporter` key mapping to the function invoked by jshint  
  - in a gulp scenario, this needs to be converted to a stream by wrppaing using gulp-jshint  
  - in this particular reporter, that is not necessary, it exports a stream directly, on the `streamReporter` key  
  - see `/lib/util/jshint-reporter` in main angularity project for example usage
